### PR TITLE
feat: Upgrade log4j dependency to fix security issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>org.qubership.atp</groupId>
     <artifactId>atp-integration-spring-boot-starter</artifactId>
-    <version>0.2.39-SNAPSHOT</version>
+    <version>0.2.40-SNAPSHOT</version>
 
     <properties>
         <java.version>21</java.version>
@@ -19,7 +19,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <spring-cloud.version>2023.0.3</spring-cloud.version>
         <atp-crypt.version>0.0.22-SNAPSHOT</atp-crypt.version>
-        <atp-common-logging.version>0.0.44-SNAPSHOT</atp-common-logging.version>
+        <atp-common-logging.version>0.0.45-SNAPSHOT</atp-common-logging.version>
         <mapstruct.version>1.5.5.Final</mapstruct.version>
         <lombok.version>1.18.30</lombok.version>
         <maven.surefire.plugin.version>2.22.0</maven.surefire.plugin.version>
@@ -126,9 +126,9 @@
             <version>1.14.1</version>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-1.2-api</artifactId>
+            <version>2.25.0</version>
         </dependency>
         <dependency>
             <groupId>org.qubership.atp.common</groupId>

--- a/src/main/java/org/qubership/atp/integration/configuration/logging/log4j/AtpLog4jPatternLayout.java
+++ b/src/main/java/org/qubership/atp/integration/configuration/logging/log4j/AtpLog4jPatternLayout.java
@@ -51,7 +51,7 @@ public class AtpLog4jPatternLayout extends PatternLayout {
         @SuppressWarnings({"ThrowableResultOfMethodCallIgnored"})
         Throwable throwable = event.getThrowableInformation() != null
                 ? event.getThrowableInformation().getThrowable() : null;
-        return new LoggingEvent(event.fqnOfCategoryClass,
+        return new LoggingEvent(event.getFQNOfLoggerClass(),
                 Logger.getLogger(event.getLoggerName()), event.timeStamp,
                 event.getLevel(), maskedMessage, throwable);
     }


### PR DESCRIPTION
Add org.apache.logging.log4j:log4j-1.2-api:2.25.0 as bridge in order to fix security vulnerabilities. 
<!-- start messages -->
### Commit messages:
[DmitryChurbanov](https://github.com/Netcracker/qubership-testing-platform-integration-library/commit/894b70375374fab71510c55f5c365c91c93c2caf) feat: add org.apache.logging.log4j:log4j-1.2-api:2.25.0 as bridge in order to fix security vulnerabilities;qubership-atp-common-logging version is changed to 0.0.45-SNAPSHOT;version is changed to 0.2.40-SNAPSHOT;
[kagw95](https://github.com/Netcracker/qubership-testing-platform-integration-library/commit/aaf697fb134111a366e7bfd4842eab36b73dd962) Merge branch 'feature/springboot-upgrade' into feature/log4j-upgrade
<!-- end messages -->
